### PR TITLE
Trim option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name" : "troytft/data-mapper-bundle",
     "description": "Allow mapping data to models",
-    "version" : "1.4.0",
+    "version" : "1.5.0",
     "type" : "symfony-bundle",
     "license" : "MIT",
     "require" : {

--- a/src/DataTransformer/ArrayOfDateTimeDataTransformer.php
+++ b/src/DataTransformer/ArrayOfDateTimeDataTransformer.php
@@ -34,7 +34,7 @@ class ArrayOfDateTimeDataTransformer extends BaseDataTransformer implements Data
         $this->timeZoneProvider = $timeZoneProvider;
     }
 
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
         parent::setOptions($options);
 

--- a/src/DataTransformer/ArrayOfEntityDataTransformer.php
+++ b/src/DataTransformer/ArrayOfEntityDataTransformer.php
@@ -17,15 +17,16 @@ class ArrayOfEntityDataTransformer extends BaseDataTransformer implements DataTr
         $this->em = $em;
     }
 
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
+        parent::setOptions($options);
+
         if (empty($options['class'])) {
             throw new BaseException('Class name can`t be empty');
         }
 
         $this->entityName = $options['class'];
         $this->fieldName = empty($options['field']) ? 'id' : $options['field'];
-        parent::setOptions($options);
     }
 
     public function transform($value)

--- a/src/DataTransformer/BaseDataTransformer.php
+++ b/src/DataTransformer/BaseDataTransformer.php
@@ -2,35 +2,51 @@
 
 namespace Troytft\DataMapperBundle\DataTransformer;
 
-class BaseDataTransformer implements DataTransformerInterface
+abstract class BaseDataTransformer implements DataTransformerInterface
 {
-    protected $options;
+    const PROPERTY_NAME_OPTION = 'propertyName';
 
     /**
-     * @return mixed
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * @return array
      */
     public function getOptions()
     {
-        return $this->options;
+        return (array) $this->options;
     }
 
     /**
-     * @param mixed $value
+     * @param array $value
      */
-    public function setOptions($value)
+    public function setOptions(array $value = [])
     {
         $this->options = $value;
 
         return $this;
     }
 
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
     public function transform($value)
     {
         return $value;
     }
 
+    /**
+     * @return string
+     */
     public function getPropertyName()
     {
-        return $this->options['propertyName'];
+        if (!isset($this->getOptions()[self::PROPERTY_NAME_OPTION])) {
+            throw new \RuntimeException('Property name must be defined!');
+        }
+
+        return (string) $this->getOptions()[self::PROPERTY_NAME_OPTION];
     }
 }

--- a/src/DataTransformer/BaseDataTransformer.php
+++ b/src/DataTransformer/BaseDataTransformer.php
@@ -2,6 +2,8 @@
 
 namespace Troytft\DataMapperBundle\DataTransformer;
 
+use Troytft\DataMapperBundle\Exception\BaseException;
+
 abstract class BaseDataTransformer implements DataTransformerInterface
 {
     const PROPERTY_NAME_OPTION = 'propertyName';
@@ -44,7 +46,7 @@ abstract class BaseDataTransformer implements DataTransformerInterface
     public function getPropertyName()
     {
         if (!isset($this->getOptions()[self::PROPERTY_NAME_OPTION])) {
-            throw new \RuntimeException('Property name must be defined!');
+            throw new BaseException('Property name must be defined!');
         }
 
         return (string) $this->getOptions()[self::PROPERTY_NAME_OPTION];

--- a/src/DataTransformer/DataTransformerInterface.php
+++ b/src/DataTransformer/DataTransformerInterface.php
@@ -5,5 +5,6 @@ namespace Troytft\DataMapperBundle\DataTransformer;
 interface DataTransformerInterface
 {
     public function transform($value);
-    public function setOptions($options);
+
+    public function setOptions(array $options);
 }

--- a/src/DataTransformer/DateTimeDataTransformer.php
+++ b/src/DataTransformer/DateTimeDataTransformer.php
@@ -33,7 +33,7 @@ class DateTimeDataTransformer extends BaseDataTransformer implements DataTransfo
         $this->timeZoneProvider = $timeZoneProvider;
     }
 
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
         parent::setOptions($options);
 

--- a/src/DataTransformer/EntityDataTransformer.php
+++ b/src/DataTransformer/EntityDataTransformer.php
@@ -17,15 +17,16 @@ class EntityDataTransformer extends BaseDataTransformer implements DataTransform
         $this->em = $em;
     }
 
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
+        parent::setOptions($options);
+
         if (empty($options['class'])) {
             throw new BaseException('Class name can`t be empty');
         }
 
         $this->entityName = $options['class'];
         $this->fieldName = empty($options['field']) ? 'id' : $options['field'];
-        parent::setOptions($options);
     }
 
     public function transform($value)

--- a/src/DataTransformer/StringDataTransformer.php
+++ b/src/DataTransformer/StringDataTransformer.php
@@ -4,8 +4,31 @@ namespace Troytft\DataMapperBundle\DataTransformer;
 
 class StringDataTransformer extends BaseDataTransformer implements DataTransformerInterface
 {
+    const TRIM_OPTION = 'trim';
+
+    public function isTrimMode()
+    {
+        if (!array_key_exists(self::TRIM_OPTION, $this->getOptions())) {
+            return false;
+        }
+
+        return (bool) $this->getOptions()[self::TRIM_OPTION];
+    }
+
+    /**
+     * @param mixed $value
+     * @return null|string
+     */
     public function transform($value)
     {
-        return $value === null || trim($value) === "" ? null : (string) $value;
+        if ($value === null || trim($value) === "") {
+            return null;
+        }
+
+        if ($this->isTrimMode()) {
+            return trim($value);
+        }
+
+        return $value;
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -130,7 +130,7 @@ class Manager
         $dataTransformer = $this->getDataTransformer($propertyAnnotation->getType());
         $dataTransformer->setOptions(array_merge($propertyAnnotation->getOptions(), [
             'model' => $this->model,
-            'propertyName' => $propertyAnnotation->getName()
+            BaseDataTransformer::PROPERTY_NAME_OPTION => $propertyAnnotation->getName()
         ]));
         $value = $dataTransformer->transform($value);
 

--- a/tests/DataTransformer/ArrayOfDateTimeDataTransformerTest.php
+++ b/tests/DataTransformer/ArrayOfDateTimeDataTransformerTest.php
@@ -27,6 +27,7 @@ class ArrayOfDateTimeDataTransformerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->transformer = new ArrayOfDateTimeDataTransformer($this->localTimeZoneProviderMock);
+        $this->transformer->setOptions(['propertyName' => 'propertyName']);
     }
 
     /**

--- a/tests/DataTransformer/DateDataTransformerTest.php
+++ b/tests/DataTransformer/DateDataTransformerTest.php
@@ -14,6 +14,7 @@ class DateDataTransformerTest extends \PHPUnit_Framework_TestCase
     public function setup()
     {
         $this->transformer = new DateDataTransformer();
+        $this->transformer->setOptions(['propertyName' => 'propertyName']);
     }
 
     /**

--- a/tests/DataTransformer/DateTimeDataTransformerTest.php
+++ b/tests/DataTransformer/DateTimeDataTransformerTest.php
@@ -27,6 +27,7 @@ class DateTimeDataTransformerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->transformer = new DateTimeDataTransformer($this->localTimeZoneProviderMock);
+        $this->transformer->setOptions(['propertyName' => 'propertyName']);
     }
 
     /**

--- a/tests/DataTransformer/StringDataTransformerTest.php
+++ b/tests/DataTransformer/StringDataTransformerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DataTransformer;
+
+use Troytft\DataMapperBundle\DataTransformer\StringDataTransformer;
+
+class StringDataTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StringDataTransformer
+     */
+    private $transformer;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->transformer = new StringDataTransformer();
+    }
+
+    /**
+     * Default test case
+     */
+    public function testBaseStringTransform()
+    {
+        $this->assertEquals('String', $this->transformer->transform('String'));
+        $this->assertEquals(null, $this->transformer->transform(null));
+        $this->assertEquals(null, $this->transformer->transform(''));
+    }
+
+    /**
+     * Transform with trim option
+     */
+    public function testTrimmedStringTransform()
+    {
+        $this->transformer->setOptions(['trim' => true]);
+
+        $this->testBaseStringTransform();
+
+        $this->assertEquals('String', $this->transformer->transform(' String '));
+        $this->assertEquals('String', $this->transformer->transform("\n\n \n\nString \n \n"));
+        $this->assertEquals("String\r \n \rwith some spaces between text", $this->transformer->transform("\t\r\n \n\nString\r \n \rwith some spaces between text\t\n    \n\n\n"));
+
+    }
+}


### PR DESCRIPTION
Добавил опцию трима строки + немного поправил типизацию при работе с опциями
Так как трима нет, то это приводит к тому что есть много строковых полей с переводами строк и всем остальным. 

+ так как каждом сеттере трим делать тоже не хочется и по всему проекту менять аннотации тоже, то можно было бы включить trim по-умолчанию